### PR TITLE
(SIMP-MAINT) Fixed bad URL to docker's libkv project

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri Sep 18 2020 Liz Nemsick <lnemsick.simp@gmail.com> - 0.7.1
+- Fixed bad URL to docker's libkv project
+
 * Wed Feb 26 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.7.0
 - Changed name of module from libkv to simpkv
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This module provides
 
 * a standard Puppet language API (functions) for using key/value stores
 
-  * The API is modeled after https://github.com/docker/simpkv#interface.
+  * The API is modeled after https://github.com/docker/libkv#interface.
   * See [REFERENCE.md](REFERENCE.md) for more details on the available
     functions.
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simpkv",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "author": "simp",
   "summary": "SIMPkv providers",
   "license": "Apache-2.0",


### PR DESCRIPTION
Fix URL that was munged when repo was renamed.