### PR TITLE
(SIMP-9112) simpkv fails Puppet 7 unit test

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -335,7 +335,6 @@ pup6.pe-unit:
 
 pup7.x-unit:
   # SIMP-9112
-  allow_failure: true
   <<: *pup_7_x
   <<: *unit_tests
 

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ ENV['PDK_DISABLE_ANALYTICS'] ||= 'true'
 gem_sources.each { |gem_source| source gem_source }
 
 group :test do
-  puppet_version = ENV['PUPPET_VERSION'] || '~> 7.0'
+  puppet_version = ENV['PUPPET_VERSION'] || '~> 6.18'
   major_puppet_version = puppet_version.scan(/(\d+)(?:\.|\Z)/).flatten.first.to_i
   gem 'rake'
   gem 'puppet', puppet_version

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ ENV['PDK_DISABLE_ANALYTICS'] ||= 'true'
 gem_sources.each { |gem_source| source gem_source }
 
 group :test do
-  puppet_version = ENV['PUPPET_VERSION'] || '~> 6.18'
+  puppet_version = ENV['PUPPET_VERSION'] || '~> 7.0'
   major_puppet_version = puppet_version.scan(/(\d+)(?:\.|\Z)/).flatten.first.to_i
   gem 'rake'
   gem 'puppet', puppet_version
@@ -37,7 +37,7 @@ end
 group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
-  gem 'simp-beaker-helpers', ENV['SIMP_BEAKER_HELPERS_VERSION'] || ['>= 1.18.7', '< 2']
+  gem 'simp-beaker-helpers', ENV['SIMP_BEAKER_HELPERS_VERSION'] || ['>= 1.21.2', '< 2']
 end
 
 # Evaluate extra gemfiles if they exist

--- a/spec/functions/simpkv/support/load_spec.rb
+++ b/spec/functions/simpkv/support/load_spec.rb
@@ -29,12 +29,14 @@ describe 'simpkv::support::load' do
   end
 
   it 'should fail when simpkv.rb does not exist' do
-    allow(File).to receive(:exists?).and_return(false)
+    allow(File).to receive(:exists?).with(any_args).and_call_original
+    allow(File).to receive(:exists?).with(/simpkv\/loader.rb/).and_return(false)
     is_expected.to run.with_params().and_raise_error(LoadError, /simpkv Internal Error: unable to load .* File not found/)
   end
 
   it 'should fail when simpkv.rb is malformed Ruby' do
-    allow(File).to receive(:read).and_return("if true\n")
+    allow(File).to receive(:read).with(any_args).and_call_original
+    allow(File).to receive(:read).with(/simpkv\/loader.rb/).and_return("if true\n")
     is_expected.to run.with_params().and_raise_error(LoadError, /simpkv Internal Error: unable to load .* syntax error/)
  end
 


### PR DESCRIPTION
Adjust File operation mocks to target only the files being
operated on in the test. This is necessary because there
are File operations now being done by the Puppet 7 machinery
in the rspec test.

SIMP-9112 #close