### PR TITLE
(SIMP-9774) Add global and env key groupings to simpkv adapter

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -368,3 +368,9 @@ pup6.pe-oel-fips:
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,oel]'
+
+pup7.x:
+  <<: *pup_7_x
+  <<: *acceptance_base
+  script:
+    - 'bundle exec rake beaker:suites[default,default]'

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,11 +1,33 @@
+* Mon Jun 21 2021 Liz Nemsick <lnemsick.simp@gmail.com> - 0.8.0
+- BREAKING CHANGES:
+  - Added 'globals' and 'environments' root directories for global and
+    Puppet-environment keys, respectively, in the normalized key paths
+    in the backend.
+    - This change makes the top-level organization of keys in the backend
+      explicit, and thus more understandable.
+    - The prefix used for global keys was changed from `<keystore root dir>` to
+      `<keystore root dir>/globals`.
+    - The prefix used for environment keys was changed from
+      `<keystore root dir>/<specific Puppet environment>` to
+      `<keystore root dir>/environments/<specific Puppet environment>`.
+    - Change required for the LDAP plugin.
+  - Replaced the confusing 'environment' backend option in each simpkv Puppet
+    function with a 'global' Boolean option.
+    - Global keys are now specified by setting 'global' to true in lieu of
+      setting 'environment' to ''.
+  - Restrict letter characters used in key and folder names to be
+    lowercase.
+    - Change required for the LDAP plugin.
+- Added
+  - More detailed plugin exception reporting in order to pinpoint plugin
+    logic problems.
+    - Now prints out the useful portion of the backtrace when an exception
+      is raised.
+    - Especially useful during plugin development.
+
 * Wed Jun 16 2021 Chris Tessmer <chris.tessmer@onyxpoint.com> - 0.8.0
 - Removed support for Puppet 5
 - Ensured support for Puppet 7 in requirements and stdlib
-
-* Tue May 25 2021 Liz Nemsick <lnemsick.simp@gmail.com> - 0.8.0
-- Restrict letter characters used in key and folder names to be
-  lowercase
-  - Change required for LDAP plugin.
 
 * Sat Dec 19 2020 Chris Tessmer <chris.tessmer@onyxpoint.com> - 0.7.2
 - Removed EL6 support

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -27,16 +27,22 @@ Deletes a `key` from the configured backend.
 
 #### Examples
 
-##### Delete a key using the default backend
+##### Delete a key from the default backend
 
 ```puppet
 simpkv::delete("hosts/${facts['fqdn']}")
 ```
 
-##### Delete a key using the backend servicing an application id
+##### Delete a key from the backend servicing an application id
 
 ```puppet
 simpkv::delete("hosts/${facts['fqdn']}", { 'app_id' => 'myapp' })
+```
+
+##### Delete a global key from the default backend
+
+```puppet
+simpkv::delete("hosts/${facts['fqdn']}", { 'global' => true })
 ```
 
 #### `simpkv::delete(String[1] $key, Optional[Hash] $options)`
@@ -55,16 +61,22 @@ Raises:
 
 ##### Examples
 
-###### Delete a key using the default backend
+###### Delete a key from the default backend
 
 ```puppet
 simpkv::delete("hosts/${facts['fqdn']}")
 ```
 
-###### Delete a key using the backend servicing an application id
+###### Delete a key from the backend servicing an application id
 
 ```puppet
 simpkv::delete("hosts/${facts['fqdn']}", { 'app_id' => 'myapp' })
+```
+
+###### Delete a global key from the default backend
+
+```puppet
+simpkv::delete("hosts/${facts['fqdn']}", { 'global' => true })
 ```
 
 ##### `key`
@@ -122,13 +134,11 @@ configuration to use via fuzzy name matching, in the absence of the
 
    * Other keys for configuration specific to the backend may also be
      present.
-* **'environment'** `String`: Puppet environment to prepend to keys.
+* **'global'** `Boolean`: Set to `true` when the key being accessed is global. Otherwise, the key
+will be tied to the Puppet environment of the node whose manifest is
+being compiled.
 
-  * When set to a non-empty string, it is prepended to the key used in
-    the backend operation.
-  * Should only be set to an empty string when the key being accessed is
-    truly global.
-  * Defaults to the Puppet environment for the node.
+  * Defaults to `false`
 * **'softfail'** `Boolean`: Whether to ignore simpkv operation failures.
 
   * When `true`, this function will return a result even when the
@@ -145,16 +155,22 @@ Deletes a whole folder from the configured backend.
 
 #### Examples
 
-##### Delete a key folder using the default backend
+##### Delete a key folder from the default backend
 
 ```puppet
 simpkv::deletetree("hosts")
 ```
 
-##### Delete a key folder using the backend servicing an appliction id
+##### Delete a key folder from the backend servicing an application id
 
 ```puppet
 simpkv::deletetree("hosts", { 'app_id' => 'myapp' })
+```
+
+##### Delete a global key folder from the default backend
+
+```puppet
+simpkv::deletetree("hosts", { 'global' => true })
 ```
 
 #### `simpkv::deletetree(String[1] $keydir, Optional[Hash] $options)`
@@ -173,16 +189,22 @@ Raises:
 
 ##### Examples
 
-###### Delete a key folder using the default backend
+###### Delete a key folder from the default backend
 
 ```puppet
 simpkv::deletetree("hosts")
 ```
 
-###### Delete a key folder using the backend servicing an appliction id
+###### Delete a key folder from the backend servicing an application id
 
 ```puppet
 simpkv::deletetree("hosts", { 'app_id' => 'myapp' })
+```
+
+###### Delete a global key folder from the default backend
+
+```puppet
+simpkv::deletetree("hosts", { 'global' => true })
 ```
 
 ##### `keydir`
@@ -240,13 +262,11 @@ configuration to use via fuzzy name matching, in the absence of the
 
    * Other keys for configuration specific to the backend may also be
      present.
-* **'environment'** `String`: Puppet environment to prepend to keys.
+* **'global'** `Boolean`: Set to `true` when the key being accessed is global. Otherwise, the key
+will be tied to the Puppet environment of the node whose manifest is
+being compiled.
 
-  * When set to a non-empty string, it is prepended to the key used in
-    the backend operation.
-  * Should only be set to an empty string when the key being accessed is
-    truly global.
-  * Defaults to the Puppet environment for the node.
+  * Defaults to `false`
 * **'softfail'** `Boolean`: Whether to ignore simpkv operation failures.
 
   * When `true`, this function will return a result even when the
@@ -279,10 +299,10 @@ if simpkv::exists("hosts/${facts['fqdn']}", { 'app_id' => 'myapp' }) {
 }
 ```
 
-##### Check for the existence of a key folder in the default backend
+##### Check for the existence of a global key folder in the default backend
 
 ```puppet
-if simpkv::exists("hosts") {
+if simpkv::exists("hosts", { 'global' => true}) {
    notify { 'hosts folder exists': }
 }
 ```
@@ -319,10 +339,10 @@ if simpkv::exists("hosts/${facts['fqdn']}", { 'app_id' => 'myapp' }) {
 }
 ```
 
-###### Check for the existence of a key folder in the default backend
+###### Check for the existence of a global key folder in the default backend
 
 ```puppet
-if simpkv::exists("hosts") {
+if simpkv::exists("hosts", { 'global' => true}) {
    notify { 'hosts folder exists': }
 }
 ```
@@ -382,13 +402,11 @@ configuration to use via fuzzy name matching, in the absence of the
 
    * Other keys for configuration specific to the backend may also be
      present.
-* **'environment'** `String`: Puppet environment to prepend to keys.
+* **'global'** `Boolean`: Set to `true` when the key being accessed is global. Otherwise, the key
+will be tied to the Puppet environment of the node whose manifest is
+being compiled.
 
-  * When set to a non-empty string, it is prepended to the key used in
-    the backend operation.
-  * Should only be set to an empty string when the key being accessed is
-    truly global.
-  * Defaults to the Puppet environment for the node.
+  * Defaults to `false`
 * **'softfail'** `Boolean`: Whether to ignore simpkv operation failures.
 
   * When `true`, this function will return a result even when the
@@ -406,21 +424,33 @@ Retrieves the value and any metadata stored at `key` from the
 
 #### Examples
 
-##### Retrieve the value and any metadata for a key in the default backend
+##### Retrieve the value and any metadata for a key from the default backend
 
 ```puppet
 $result = simpkv::get("database/${facts['fqdn']}")
 class { 'wordpress':
-  db_host => $result['value']
+  db_host => $result['value'],
+  db_info => $result['metadata']
 }
 ```
 
-##### Retrieve the value and any metadata for a key in the backend servicing an application id
+##### Retrieve the value and any metadata for a key from the backend servicing an application id
 
 ```puppet
 $result = simpkv::get("database/${facts['fqdn']}", { 'app_id' => 'myapp' })
 class { 'wordpress':
-  db_host => $result['value']
+  db_host => $result['value'],
+  db_info => $result['metadata']
+}
+```
+
+##### Retrieve the value and any metadata for a global key from the default backend
+
+```puppet
+$result = simpkv::get("database/${facts['fqdn']}", { 'global' => true })
+class { 'wordpress':
+  db_host => $result['value'],
+  db_info => $result['metadata']
 }
 ```
 
@@ -445,21 +475,33 @@ Raises:
 
 ##### Examples
 
-###### Retrieve the value and any metadata for a key in the default backend
+###### Retrieve the value and any metadata for a key from the default backend
 
 ```puppet
 $result = simpkv::get("database/${facts['fqdn']}")
 class { 'wordpress':
-  db_host => $result['value']
+  db_host => $result['value'],
+  db_info => $result['metadata']
 }
 ```
 
-###### Retrieve the value and any metadata for a key in the backend servicing an application id
+###### Retrieve the value and any metadata for a key from the backend servicing an application id
 
 ```puppet
 $result = simpkv::get("database/${facts['fqdn']}", { 'app_id' => 'myapp' })
 class { 'wordpress':
-  db_host => $result['value']
+  db_host => $result['value'],
+  db_info => $result['metadata']
+}
+```
+
+###### Retrieve the value and any metadata for a global key from the default backend
+
+```puppet
+$result = simpkv::get("database/${facts['fqdn']}", { 'global' => true })
+class { 'wordpress':
+  db_host => $result['value'],
+  db_info => $result['metadata']
 }
 ```
 
@@ -518,13 +560,11 @@ configuration to use via fuzzy name matching, in the absence of the
 
    * Other keys for configuration specific to the backend may also be
      present.
-* **'environment'** `String`: Puppet environment to prepend to keys.
+* **'global'** `Boolean`: Set to `true` when the key being accessed is global. Otherwise, the key
+will be tied to the Puppet environment of the node whose manifest is
+being compiled.
 
-  * When set to a non-empty string, it is prepended to the key used in
-    the backend operation.
-  * Should only be set to an empty string when the key being accessed is
-    truly global.
-  * Defaults to the Puppet environment for the node.
+  * Defaults to `false`
 * **'softfail'** `Boolean`: Whether to ignore simpkv operation failures.
 
   * When `true`, this function will return a result even when the
@@ -544,7 +584,7 @@ about the specified key folder is returned.
 
 #### Examples
 
-##### Retrieve the list of key info for a key folder in the default backend
+##### Retrieve the list of key info for a key folder from the default backend
 
 ```puppet
 $result = simpkv::list('hosts')
@@ -555,34 +595,21 @@ $result['keys'].each |$host, $info | {
 }
 ```
 
-##### Retrieve the list of key info for a key folder in the backend servicing an application id
+##### Retrieve the list of sub-folders in a key folder from the backend servicing an application id
 
 ```puppet
-$result = simpkv::list('hosts', { 'app_id' => 'myapp' })
-$result['keys'].each |$host, $info | {
-  host { $host:
-    ip => $info['value'],
-  }
-}
-```
-
-##### Retrieve the list of sub-folders in a key folder in the default backend
-
-```puppet
-$result = simpkv::list('applications')
+$result = simpkv::list('applications', { 'app_id' => 'myapp' })
 notice("Supported applications: ${join($result['folders'], ' ')}")
 ```
 
-##### Retrieve the top folder list for the environment in the default backend
+##### Retrieve the top level list of global keys/folders in the default backend
 
 ```puppet
-$result = simpkv::list('/')
-```
-
-##### Retrieve the list of environments supported by the default backend
-
-```puppet
-$result = simpkv::list('/', { 'environment' => '' })
+$result = simpkv::list('/', { 'global' = true })
+notice("Global folders: ${join($result['folders'], ' ')}")
+$result['keys'].each |$key, $info | {
+  notice("Global key ${key}: value=${info['value']} metadata=${info['metadata']}")
+}
 ```
 
 #### `simpkv::list(String[1] $keydir, Optional[Hash] $options)`
@@ -610,7 +637,7 @@ Raises:
 
 ##### Examples
 
-###### Retrieve the list of key info for a key folder in the default backend
+###### Retrieve the list of key info for a key folder from the default backend
 
 ```puppet
 $result = simpkv::list('hosts')
@@ -621,34 +648,21 @@ $result['keys'].each |$host, $info | {
 }
 ```
 
-###### Retrieve the list of key info for a key folder in the backend servicing an application id
+###### Retrieve the list of sub-folders in a key folder from the backend servicing an application id
 
 ```puppet
-$result = simpkv::list('hosts', { 'app_id' => 'myapp' })
-$result['keys'].each |$host, $info | {
-  host { $host:
-    ip => $info['value'],
-  }
-}
-```
-
-###### Retrieve the list of sub-folders in a key folder in the default backend
-
-```puppet
-$result = simpkv::list('applications')
+$result = simpkv::list('applications', { 'app_id' => 'myapp' })
 notice("Supported applications: ${join($result['folders'], ' ')}")
 ```
 
-###### Retrieve the top folder list for the environment in the default backend
+###### Retrieve the top level list of global keys/folders in the default backend
 
 ```puppet
-$result = simpkv::list('/')
-```
-
-###### Retrieve the list of environments supported by the default backend
-
-```puppet
-$result = simpkv::list('/', { 'environment' => '' })
+$result = simpkv::list('/', { 'global' = true })
+notice("Global folders: ${join($result['folders'], ' ')}")
+$result['keys'].each |$key, $info | {
+  notice("Global key ${key}: value=${info['value']} metadata=${info['metadata']}")
+}
 ```
 
 ##### `keydir`
@@ -706,13 +720,11 @@ configuration to use via fuzzy name matching, in the absence of the
 
    * Other keys for configuration specific to the backend may also be
      present.
-* **'environment'** `String`: Puppet environment to prepend to keys.
+* **'global'** `Boolean`: Set to `true` when the key being accessed is global. Otherwise, the key
+will be tied to the Puppet environment of the node whose manifest is
+being compiled.
 
-  * When set to a non-empty string, it is prepended to the key used in
-    the backend operation.
-  * Should only be set to an empty string when the key being accessed is
-    truly global.
-  * Defaults to the Puppet environment for the node.
+  * Defaults to `false`
 * **'softfail'** `Boolean`: Whether to ignore simpkv operation failures.
 
   * When `true`, this function will return a result even when the
@@ -730,25 +742,24 @@ Optionally sets metadata along with the `value`.
 
 #### Examples
 
-##### Set a key using the default backend
+##### Set a key in the default backend
 
 ```puppet
 simpkv::put("hosts/${facts['clientcert']}", $facts['ipaddress'])
 ```
 
-##### Set a key with metadata using the default backend
-
-```puppet
-$meta = { 'rack_id' => 183 }
-simpkv::put("hosts/${facts['clientcert']}", $facts['ipaddress'], $meta)
-```
-
-##### Set a key with metadata using the backend servicing an application id
+##### Set a key with metadata in the backend servicing an application id
 
 ```puppet
 $meta = { 'rack_id' => 183 }
 $opts = { 'app_id' => 'myapp' }
 simpkv::put("hosts/${facts['clientcert']}", $facts['ipaddress'], $meta, $opts)
+```
+
+##### Set a gobal key in the default backend
+
+```puppet
+simpkv::put("hosts/${facts['clientcert']}", $facts['ipaddress'], { 'global' => true })
 ```
 
 #### `simpkv::put(String[1] $key, NotUndef $value, Optional[Hash] $metadata, Optional[Hash] $options)`
@@ -768,25 +779,24 @@ Raises:
 
 ##### Examples
 
-###### Set a key using the default backend
+###### Set a key in the default backend
 
 ```puppet
 simpkv::put("hosts/${facts['clientcert']}", $facts['ipaddress'])
 ```
 
-###### Set a key with metadata using the default backend
-
-```puppet
-$meta = { 'rack_id' => 183 }
-simpkv::put("hosts/${facts['clientcert']}", $facts['ipaddress'], $meta)
-```
-
-###### Set a key with metadata using the backend servicing an application id
+###### Set a key with metadata in the backend servicing an application id
 
 ```puppet
 $meta = { 'rack_id' => 183 }
 $opts = { 'app_id' => 'myapp' }
 simpkv::put("hosts/${facts['clientcert']}", $facts['ipaddress'], $meta, $opts)
+```
+
+###### Set a gobal key in the default backend
+
+```puppet
+simpkv::put("hosts/${facts['clientcert']}", $facts['ipaddress'], { 'global' => true })
 ```
 
 ##### `key`
@@ -856,13 +866,11 @@ configuration to use via fuzzy name matching, in the absence of the
 
    * Other keys for configuration specific to the backend may also be
      present.
-* **'environment'** `String`: Puppet environment to prepend to keys.
+* **'global'** `Boolean`: Set to `true` when the key being accessed is global. Otherwise, the key
+will be tied to the Puppet environment of the node whose manifest is
+being compiled.
 
-  * When set to a non-empty string, it is prepended to the key used in
-    the backend operation.
-  * Should only be set to an empty string when the key being accessed is
-    truly global.
-  * Defaults to the Puppet environment for the node.
+  * Defaults to `false`
 * **'softfail'** `Boolean`: Whether to ignore simpkv operation failures.
 
   * When `true`, this function will return a result even when the

--- a/docs/Design_Prototype2.md
+++ b/docs/Design_Prototype2.md
@@ -466,13 +466,11 @@ keys in this Hash are as follows:
   * See [Backend Configuration Entries](#backend-configuration-entries)
     for more details about a backend configuration Hash.
 
-* `environment`: Optional String.  Puppet environment to prepend to keys.
+* `global`: Optional Boolean. Set to `true` when the key being accessed
+  is global. Otherwise, the key will be tied to the Puppet environment
+  of the node whose manifest is being compiled.
 
-  * When set to a non-empty string, it is prepended to the key or key folder
-    used in a backend operation.
-  * Should only be set to an empty string when the key being accessed is truly
-    global.
-  * Defaults to the Puppet environment for the node.
+  * Defaults to `false`.
 
 * `softfail`: Optional Boolean. Whether to ignore simpkv operation failures.
 
@@ -666,13 +664,11 @@ The available options (all optional) are as follows:
    * Other keys for configuration specific to the backend may also be
      present.
 
-* `environment`: String.  Puppet environment to prepend to keys.
+* `global`: Boolean. Set to `true` when the key being accessed
+  is global. Otherwise, the key will be tied to the Puppet environment
+  of the node whose manifest is being compiled.
 
-  * When set to a non-empty string, it is prepended to the key used in
-    the backend operation.
-  * Should only be set to an empty string when the key being accessed is
-    truly global.
-  * Defaults to the Puppet environment for the node.
+  * Defaults to `false`.
 
 #### Function Signatures
 

--- a/lib/puppet/functions/simpkv/delete.rb
+++ b/lib/puppet/functions/simpkv/delete.rb
@@ -55,14 +55,12 @@ Puppet::Functions.create_function(:'simpkv::delete') do
   #      * Other keys for configuration specific to the backend may also be
   #        present.
   #
-  # @option options [String] 'environment'
-  #   Puppet environment to prepend to keys.
+  # @option options [Boolean] 'global'
+  #   Set to `true` when the key being accessed is global. Otherwise, the key
+  #   will be tied to the Puppet environment of the node whose manifest is
+  #   being compiled.
   #
-  #     * When set to a non-empty string, it is prepended to the key used in
-  #       the backend operation.
-  #     * Should only be set to an empty string when the key being accessed is
-  #       truly global.
-  #     * Defaults to the Puppet environment for the node.
+  #     * Defaults to `false`
   #
   # @option options [Boolean] 'softfail'
   #   Whether to ignore simpkv operation failures.
@@ -84,11 +82,14 @@ Puppet::Functions.create_function(:'simpkv::delete') do
   #   backend operation fails and 'softfail' is `true` in the merged backend
   #   options
   #
-  # @example Delete a key using the default backend
+  # @example Delete a key from the default backend
   #   simpkv::delete("hosts/${facts['fqdn']}")
   #
-  # @example Delete a key using the backend servicing an application id
+  # @example Delete a key from the backend servicing an application id
   #   simpkv::delete("hosts/${facts['fqdn']}", { 'app_id' => 'myapp' })
+  #
+  # @example Delete a global key from the default backend
+  #   simpkv::delete("hosts/${facts['fqdn']}", { 'global' => true })
   #
   dispatch :delete do
     required_param 'String[1]', :key

--- a/lib/puppet/functions/simpkv/deletetree.rb
+++ b/lib/puppet/functions/simpkv/deletetree.rb
@@ -55,14 +55,12 @@ Puppet::Functions.create_function(:'simpkv::deletetree') do
   #      * Other keys for configuration specific to the backend may also be
   #        present.
   #
-  # @option options [String] 'environment'
-  #   Puppet environment to prepend to keys.
+  # @option options [Boolean] 'global'
+  #   Set to `true` when the key being accessed is global. Otherwise, the key
+  #   will be tied to the Puppet environment of the node whose manifest is
+  #   being compiled.
   #
-  #     * When set to a non-empty string, it is prepended to the key used in
-  #       the backend operation.
-  #     * Should only be set to an empty string when the key being accessed is
-  #       truly global.
-  #     * Defaults to the Puppet environment for the node.
+  #     * Defaults to `false`
   #
   # @option options [Boolean] 'softfail'
   #   Whether to ignore simpkv operation failures.
@@ -84,11 +82,14 @@ Puppet::Functions.create_function(:'simpkv::deletetree') do
   #   backend operation fails and 'softfail' is `true` in the merged backend
   #   options
   #
-  # @example Delete a key folder using the default backend
+  # @example Delete a key folder from the default backend
   #   simpkv::deletetree("hosts")
   #
-  # @example Delete a key folder using the backend servicing an appliction id
+  # @example Delete a key folder from the backend servicing an application id
   #   simpkv::deletetree("hosts", { 'app_id' => 'myapp' })
+  #
+  # @example Delete a global key folder from the default backend
+  #   simpkv::deletetree("hosts", { 'global' => true })
   #
   dispatch :deletetree do
     required_param 'String[1]', :keydir

--- a/lib/puppet/functions/simpkv/exists.rb
+++ b/lib/puppet/functions/simpkv/exists.rb
@@ -55,14 +55,12 @@ Puppet::Functions.create_function(:'simpkv::exists') do
   #      * Other keys for configuration specific to the backend may also be
   #        present.
   #
-  # @option options [String] 'environment'
-  #   Puppet environment to prepend to keys.
+  # @option options [Boolean] 'global'
+  #   Set to `true` when the key being accessed is global. Otherwise, the key
+  #   will be tied to the Puppet environment of the node whose manifest is
+  #   being compiled.
   #
-  #     * When set to a non-empty string, it is prepended to the key used in
-  #       the backend operation.
-  #     * Should only be set to an empty string when the key being accessed is
-  #       truly global.
-  #     * Defaults to the Puppet environment for the node.
+  #     * Defaults to `false`
   #
   # @option options [Boolean] 'softfail'
   #   Whether to ignore simpkv operation failures.
@@ -94,8 +92,8 @@ Puppet::Functions.create_function(:'simpkv::exists') do
   #      notify { "hosts/${facts['fqdn']} exists": }
   #   }
   #
-  # @example Check for the existence of a key folder in the default backend
-  #   if simpkv::exists("hosts") {
+  # @example Check for the existence of a global key folder in the default backend
+  #   if simpkv::exists("hosts", { 'global' => true}) {
   #      notify { 'hosts folder exists': }
   #   }
   #

--- a/lib/puppet/functions/simpkv/get.rb
+++ b/lib/puppet/functions/simpkv/get.rb
@@ -56,14 +56,12 @@ Puppet::Functions.create_function(:'simpkv::get') do
   #      * Other keys for configuration specific to the backend may also be
   #        present.
   #
-  # @option options [String] 'environment'
-  #   Puppet environment to prepend to keys.
+  # @option options [Boolean] 'global'
+  #   Set to `true` when the key being accessed is global. Otherwise, the key
+  #   will be tied to the Puppet environment of the node whose manifest is
+  #   being compiled.
   #
-  #     * When set to a non-empty string, it is prepended to the key used in
-  #       the backend operation.
-  #     * Should only be set to an empty string when the key being accessed is
-  #       truly global.
-  #     * Defaults to the Puppet environment for the node.
+  #     * Defaults to `false`
   #
   # @option options [Boolean] 'softfail'
   #   Whether to ignore simpkv operation failures.
@@ -89,16 +87,25 @@ Puppet::Functions.create_function(:'simpkv::get') do
   #   * Hash may have a 'metadata' key containing a Hash with any metadata for
   #     the key
   #
-  # @example Retrieve the value and any metadata for a key in the default backend
+  # @example Retrieve the value and any metadata for a key from the default backend
   #  $result = simpkv::get("database/${facts['fqdn']}")
   #  class { 'wordpress':
-  #    db_host => $result['value']
+  #    db_host => $result['value'],
+  #    db_info => $result['metadata']
   #  }
   #
-  # @example Retrieve the value and any metadata for a key in the backend servicing an application id
+  # @example Retrieve the value and any metadata for a key from the backend servicing an application id
   #  $result = simpkv::get("database/${facts['fqdn']}", { 'app_id' => 'myapp' })
   #  class { 'wordpress':
-  #    db_host => $result['value']
+  #    db_host => $result['value'],
+  #    db_info => $result['metadata']
+  #  }
+  #
+  # @example Retrieve the value and any metadata for a global key from the default backend
+  #  $result = simpkv::get("database/${facts['fqdn']}", { 'global' => true })
+  #  class { 'wordpress':
+  #    db_host => $result['value'],
+  #    db_info => $result['metadata']
   #  }
   #
   dispatch :get do

--- a/lib/puppet/functions/simpkv/list.rb
+++ b/lib/puppet/functions/simpkv/list.rb
@@ -58,14 +58,12 @@ Puppet::Functions.create_function(:'simpkv::list') do
   #      * Other keys for configuration specific to the backend may also be
   #        present.
   #
-  # @option options [String] 'environment'
-  #   Puppet environment to prepend to keys.
+  # @option options [Boolean] 'global'
+  #   Set to `true` when the key being accessed is global. Otherwise, the key
+  #   will be tied to the Puppet environment of the node whose manifest is
+  #   being compiled.
   #
-  #     * When set to a non-empty string, it is prepended to the key used in
-  #       the backend operation.
-  #     * Should only be set to an empty string when the key being accessed is
-  #       truly global.
-  #     * Defaults to the Puppet environment for the node.
+  #     * Defaults to `false`
   #
   # @option options [Boolean] 'softfail'
   #   Whether to ignore simpkv operation failures.
@@ -93,7 +91,7 @@ Puppet::Functions.create_function(:'simpkv::list') do
   #       'metadata' key.
   #   * 'folders' attribute is an Array of sub-folder names
   #
-  # @example Retrieve the list of key info for a key folder in the default backend
+  # @example Retrieve the list of key info for a key folder from the default backend
   #   $result = simpkv::list('hosts')
   #   $result['keys'].each |$host, $info | {
   #     host { $host:
@@ -101,23 +99,16 @@ Puppet::Functions.create_function(:'simpkv::list') do
   #     }
   #   }
   #
-  # @example Retrieve the list of key info for a key folder in the backend servicing an application id
-  #   $result = simpkv::list('hosts', { 'app_id' => 'myapp' })
-  #   $result['keys'].each |$host, $info | {
-  #     host { $host:
-  #       ip => $info['value'],
-  #     }
-  #   }
-  #
-  # @example Retrieve the list of sub-folders in a key folder in the default backend
-  #   $result = simpkv::list('applications')
+  # @example Retrieve the list of sub-folders in a key folder from the backend servicing an application id
+  #   $result = simpkv::list('applications', { 'app_id' => 'myapp' })
   #   notice("Supported applications: ${join($result['folders'], ' ')}")
   #
-  # @example Retrieve the top folder list for the environment in the default backend
-  #   $result = simpkv::list('/')
-  #
-  # @example Retrieve the list of environments supported by the default backend
-  #   $result = simpkv::list('/', { 'environment' => '' })
+  # @example Retrieve the top level list of global keys/folders in the default backend
+  #   $result = simpkv::list('/', { 'global' = true })
+  #   notice("Global folders: ${join($result['folders'], ' ')}")
+  #   $result['keys'].each |$key, $info | {
+  #     notice("Global key ${key}: value=${info['value']} metadata=${info['metadata']}")
+  #   }
   #
   dispatch :list do
     required_param 'String[1]', :keydir

--- a/lib/puppet/functions/simpkv/put.rb
+++ b/lib/puppet/functions/simpkv/put.rb
@@ -58,14 +58,12 @@ Puppet::Functions.create_function(:'simpkv::put') do
   #      * Other keys for configuration specific to the backend may also be
   #        present.
   #
-  # @option options [String] 'environment'
-  #   Puppet environment to prepend to keys.
+  # @option options [Boolean] 'global'
+  #   Set to `true` when the key being accessed is global. Otherwise, the key
+  #   will be tied to the Puppet environment of the node whose manifest is
+  #   being compiled.
   #
-  #     * When set to a non-empty string, it is prepended to the key used in
-  #       the backend operation.
-  #     * Should only be set to an empty string when the key being accessed is
-  #       truly global.
-  #     * Defaults to the Puppet environment for the node.
+  #     * Defaults to `false`
   #
   # @option options [Boolean] 'softfail'
   #   Whether to ignore simpkv operation failures.
@@ -87,17 +85,16 @@ Puppet::Functions.create_function(:'simpkv::put') do
   #   backend operation fails and 'softfail' is `true` in the merged backend
   #   options
   #
-  # @example Set a key using the default backend
+  # @example Set a key in the default backend
   #   simpkv::put("hosts/${facts['clientcert']}", $facts['ipaddress'])
   #
-  # @example Set a key with metadata using the default backend
-  #   $meta = { 'rack_id' => 183 }
-  #   simpkv::put("hosts/${facts['clientcert']}", $facts['ipaddress'], $meta)
-  #
-  # @example Set a key with metadata using the backend servicing an application id
+  # @example Set a key with metadata in the backend servicing an application id
   #   $meta = { 'rack_id' => 183 }
   #   $opts = { 'app_id' => 'myapp' }
   #   simpkv::put("hosts/${facts['clientcert']}", $facts['ipaddress'], $meta, $opts)
+  #
+  # @example Set a gobal key in the default backend
+  #   simpkv::put("hosts/${facts['clientcert']}", $facts['ipaddress'], { 'global' => true })
   #
   dispatch :put do
     required_param 'String[1]', :key

--- a/lib/puppet/functions/simpkv/support/config/merge.rb
+++ b/lib/puppet/functions/simpkv/support/config/merge.rb
@@ -54,9 +54,12 @@ Puppet::Functions.create_function(:'simpkv::support::config::merge') do
     return merged_options
   end
 
-  # merge options; set defaults for 'backend', 'environment', and 'softfail'
-  # when missing; and when 'backends' is missing, insert a 'default' backend
-  # of type 'file'.
+  # merge options; set defaults for 'backend', 'environment', 'global' and
+  # 'softfail' when missing; and when 'backends' is missing, insert a 'default'
+  # backend of type 'file'.
+  #
+  # 'environment' is an internal option required by the simpkv adapter. It
+  # is used to generate the environment-specific prefix to the key path.
   def merge_options(options)
     require 'deep_merge'
     # deep_merge will not work with frozen options, so make a deep copy
@@ -101,11 +104,12 @@ Puppet::Functions.create_function(:'simpkv::support::config::merge') do
       merged_options['softfail'] = false
     end
 
-    unless merged_options.has_key?('environment')
-      merged_options['environment'] = closure_scope.compiler.environment.to_s
+    unless merged_options.has_key?('global')
+      merged_options['global'] = false
     end
 
-    merged_options['environment'] = '' if merged_options['environment'].nil?
+    merged_options['environment'] = closure_scope.compiler.environment.to_s
+
     merged_options
   end
 end

--- a/lib/puppet_x/simpkv/file_plugin.rb
+++ b/lib/puppet_x/simpkv/file_plugin.rb
@@ -68,6 +68,10 @@ plugin_class = Class.new do
       Puppet.debug("simpkv plugin #{name}: Using default lock timeout #{@lock_timeout_seconds}")
     end
 
+    # create parent directories for global and Puppet environment keys
+    ensure_folder_path('globals')
+    ensure_folder_path('environments')
+
     Puppet.debug("#{@name} simpkv plugin for #{@root_path} constructed")
   end
 

--- a/lib/puppet_x/simpkv/plugin_template.rb
+++ b/lib/puppet_x/simpkv/plugin_template.rb
@@ -76,6 +76,8 @@ plugin_class = Class.new do
     @name = name
 
     # FIXME: insert validation and set up code here
+    # Be sure to create 'globals' and 'environments' sub-folders off of the
+    # root directory.
 
     Puppet.debug("#{@name} simpkv plugin constructed")
   end

--- a/spec/acceptance/suites/default/file_plugin_spec.rb
+++ b/spec/acceptance/suites/default/file_plugin_spec.rb
@@ -77,29 +77,37 @@ describe 'simpkv file plugin' do
         end
 
         [
-          '/var/simp/simpkv/file/class/production/from_class/boolean',
-          '/var/simp/simpkv/file/class/production/from_class/string',
-          '/var/simp/simpkv/file/class/production/from_class/integer',
-          '/var/simp/simpkv/file/class/production/from_class/float',
-          '/var/simp/simpkv/file/class/production/from_class/array_strings',
-          '/var/simp/simpkv/file/class/production/from_class/array_integers',
-          '/var/simp/simpkv/file/class/production/from_class/hash',
+          '/var/simp/simpkv/file/class/globals/from_class/boolean',
+          '/var/simp/simpkv/file/class/globals/from_class/string',
+          '/var/simp/simpkv/file/class/globals/from_class/integer',
+          '/var/simp/simpkv/file/class/globals/from_class/float',
+          '/var/simp/simpkv/file/class/globals/from_class/array_strings',
+          '/var/simp/simpkv/file/class/globals/from_class/array_integers',
+          '/var/simp/simpkv/file/class/globals/from_class/hash',
 
-          '/var/simp/simpkv/file/class/production/from_class/boolean_with_meta',
-          '/var/simp/simpkv/file/class/production/from_class/string_with_meta',
-          '/var/simp/simpkv/file/class/production/from_class/integer_with_meta',
-          '/var/simp/simpkv/file/class/production/from_class/float_with_meta',
-          '/var/simp/simpkv/file/class/production/from_class/array_strings_with_meta',
-          '/var/simp/simpkv/file/class/production/from_class/array_integers_with_meta',
-          '/var/simp/simpkv/file/class/production/from_class/hash_with_meta',
+          '/var/simp/simpkv/file/class/environments/production/from_class/boolean',
+          '/var/simp/simpkv/file/class/environments/production/from_class/string',
+          '/var/simp/simpkv/file/class/environments/production/from_class/integer',
+          '/var/simp/simpkv/file/class/environments/production/from_class/float',
+          '/var/simp/simpkv/file/class/environments/production/from_class/array_strings',
+          '/var/simp/simpkv/file/class/environments/production/from_class/array_integers',
+          '/var/simp/simpkv/file/class/environments/production/from_class/hash',
 
-          '/var/simp/simpkv/file/class/production/from_class/boolean_from_pfunction',
-          '/var/simp/simpkv/file/default/production/from_class/boolean_from_pfunction_no_app_id',
+          '/var/simp/simpkv/file/class/environments/production/from_class/boolean_with_meta',
+          '/var/simp/simpkv/file/class/environments/production/from_class/string_with_meta',
+          '/var/simp/simpkv/file/class/environments/production/from_class/integer_with_meta',
+          '/var/simp/simpkv/file/class/environments/production/from_class/float_with_meta',
+          '/var/simp/simpkv/file/class/environments/production/from_class/array_strings_with_meta',
+          '/var/simp/simpkv/file/class/environments/production/from_class/array_integers_with_meta',
+          '/var/simp/simpkv/file/class/environments/production/from_class/hash_with_meta',
 
-          '/var/simp/simpkv/file/define_instance/production/from_define/define2/string',
-          '/var/simp/simpkv/file/define_instance/production/from_define/define2/string_from_pfunction',
-          '/var/simp/simpkv/file/define_type/production/from_define/define1/string',
-          '/var/simp/simpkv/file/define_type/production/from_define/define1/string_from_pfunction'
+          '/var/simp/simpkv/file/class/environments/production/from_class/boolean_from_pfunction',
+          '/var/simp/simpkv/file/default/environments/production/from_class/boolean_from_pfunction_no_app_id',
+
+          '/var/simp/simpkv/file/define_instance/environments/production/from_define/define2/string',
+          '/var/simp/simpkv/file/define_instance/environments/production/from_define/define2/string_from_pfunction',
+          '/var/simp/simpkv/file/define_type/environments/production/from_define/define1/string',
+          '/var/simp/simpkv/file/define_type/environments/production/from_define/define1/string_from_pfunction'
         ].each do |file|
           # validation of content will be done in 'get' test
           it "should create #{file}" do
@@ -171,13 +179,13 @@ describe 'simpkv file plugin' do
         end
 
         [
-          '/var/simp/simpkv/file/class/production/from_class/boolean',
-          '/var/simp/simpkv/file/class/production/from_class/string',
-          '/var/simp/simpkv/file/class/production/from_class/integer',
-          '/var/simp/simpkv/file/class/production/from_class/float',
-          '/var/simp/simpkv/file/class/production/from_class/array_strings',
-          '/var/simp/simpkv/file/class/production/from_class/array_integers',
-          '/var/simp/simpkv/file/class/production/from_class/hash',
+          '/var/simp/simpkv/file/class/environments/production/from_class/boolean',
+          '/var/simp/simpkv/file/class/environments/production/from_class/string',
+          '/var/simp/simpkv/file/class/environments/production/from_class/integer',
+          '/var/simp/simpkv/file/class/environments/production/from_class/float',
+          '/var/simp/simpkv/file/class/environments/production/from_class/array_strings',
+          '/var/simp/simpkv/file/class/environments/production/from_class/array_integers',
+          '/var/simp/simpkv/file/class/environments/production/from_class/hash',
         ].each do |file|
           it "should remove #{file}" do
             expect( file_exists_on(host, file) ).to be false
@@ -190,9 +198,9 @@ describe 'simpkv file plugin' do
       context 'simpkv deletetree operation' do
         let(:manifest) {
           <<-EOS
-          # class uses simpkv::deletetree to remove the remaining keys in the 'file/class'
-          # backend and the simpkv::exists to verify all keys are gone; fails compilation
-          # if any keys remain
+          # class uses simpkv::deletetree to remove the remaining Puppet env and
+          # global keys in the 'file/class' backend and the simpkv::exists to
+          # verify all keys are gone; fails compilation if any keys remain
           class { 'simpkv_test::deletetree': }
           EOS
         }
@@ -201,8 +209,9 @@ describe 'simpkv file plugin' do
           apply_manifest_on(host, manifest, :catch_failures => true)
         end
 
-        it 'should remove specified folder' do
-          expect( file_exists_on(host, '/var/simp/simpkv/file/class/production/from_class/') ).to be false
+        it 'should remove specified folders' do
+          expect( file_exists_on(host, '/var/simp/simpkv/file/class/environments/production/from_class/') ).to be false
+          expect( file_exists_on(host, '/var/simp/simpkv/file/class/globals/from_class/') ).to be false
         end
       end
 
@@ -228,8 +237,8 @@ describe 'simpkv file plugin' do
           end
 
           [
-            '/var/simp/simpkv/file/default/production/from_class/binary',
-            '/var/simp/simpkv/file/default/production/from_class/binary_with_meta'
+            '/var/simp/simpkv/file/default/environments/production/from_class/binary',
+            '/var/simp/simpkv/file/default/environments/production/from_class/binary_with_meta'
           ].each do |file|
             it "should create #{file}" do
               expect( file_exists_on(host, file) ).to be true
@@ -279,10 +288,10 @@ describe 'simpkv file plugin' do
 
       it 'should store keys in auto-default backend' do
         [
-          '/var/simp/simpkv/file/auto_default/production/from_define/define2/string',
-          '/var/simp/simpkv/file/auto_default/production/from_define/define2/string_from_pfunction',
-          '/var/simp/simpkv/file/auto_default/production/from_define/define1/string',
-          '/var/simp/simpkv/file/auto_default/production/from_define/define1/string_from_pfunction'
+          '/var/simp/simpkv/file/auto_default/environments/production/from_define/define2/string',
+          '/var/simp/simpkv/file/auto_default/environments/production/from_define/define2/string_from_pfunction',
+          '/var/simp/simpkv/file/auto_default/environments/production/from_define/define1/string',
+          '/var/simp/simpkv/file/auto_default/environments/production/from_define/define1/string_from_pfunction'
         ].each do |file|
           expect( file_exists_on(host, file) ).to be true
         end

--- a/spec/fixtures/hieradata/multiple_backends.yaml
+++ b/spec/fixtures/hieradata/multiple_backends.yaml
@@ -16,7 +16,6 @@
 
   simpkv::options:
     # global options
-    environment: "myenv"
     softfail: false
 
     # Hash of backend configuration to be used to lookup the appropriate

--- a/spec/fixtures/hieradata/multiple_backends_missing_default.yaml
+++ b/spec/fixtures/hieradata/multiple_backends_missing_default.yaml
@@ -16,7 +16,6 @@
 
   simpkv::options:
     # global options
-    environment: "myenv"
     softfail: false
 
     # Hash of backend configuration to be used to lookup the appropriate

--- a/spec/fixtures/hieradata/one_backend.yaml
+++ b/spec/fixtures/hieradata/one_backend.yaml
@@ -1,7 +1,6 @@
 ---
 simpkv::options:
   # global options
-  environment: "myenv"
   softfail: false
 
   # we only have one backend, so might as well set it explicitly

--- a/spec/functions/simpkv/delete_spec.rb
+++ b/spec/functions/simpkv/delete_spec.rb
@@ -2,8 +2,11 @@ require 'spec_helper'
 
 describe 'simpkv::delete' do
 
-# Going to use file plugin and the test plugins in spec/support/test_plugins
-# for these unit tests.
+  # tell puppet-rspec to set Puppet environment to 'myenv'
+  let(:environment) { 'myenv' }
+
+  # Going to use file plugin and the test plugins in spec/support/test_plugins
+  # for these unit tests.
   before(:each) do
     # set up configuration for the file plugin
     @tmpdir = Dir.mktmpdir
@@ -11,7 +14,6 @@ describe 'simpkv::delete' do
     @root_path_default_app_id = File.join(@tmpdir, 'simpkv', 'default_app_id')
     @root_path_default        = File.join(@tmpdir, 'simpkv', 'default')
     options_base = {
-      'environment' => 'production',
       'backends'    => {
         # will use failer plugin for catastrophic error cases, because
         # it is badly behaved and raises exceptions on all operations
@@ -48,13 +50,10 @@ describe 'simpkv::delete' do
     FileUtils.remove_entry_secure(@tmpdir)
   end
 
-  # The tests will verify most of the function behavior without simpkv::options
-  # specified and then verify options merging when simpkv::options is specified.
-
-  context 'without simpkv::options' do
-    let(:test_file_keydir) { File.join(@root_path_test_file, 'production') }
-    let(:default_app_id_keydir) { File.join(@root_path_default_app_id, 'production') }
-    let(:default_keydir) { File.join(@root_path_default, 'production') }
+  context 'basic operation' do
+    let(:test_file_keydir) { File.join(@root_path_test_file, 'environments', environment) }
+    let(:default_app_id_keydir) { File.join(@root_path_default_app_id, 'environments', environment) }
+    let(:default_keydir) { File.join(@root_path_default, 'environments', environment) }
     let(:key) { 'mykey' }
 
     it 'should delete an existing key in a specific backend in options' do
@@ -96,13 +95,11 @@ describe 'simpkv::delete' do
       # is constructed
       subject()
       key_file = File.join(Puppet.settings[:vardir], 'simp', 'simpkv', 'file',
-        'auto_default', environment, key)
+        'auto_default', 'environments', environment, key)
       FileUtils.mkdir_p(File.dirname(key_file))
       FileUtils.touch(key_file)
 
       is_expected.to run.with_params(key).and_return(true)
-      key_file = File.join(Puppet.settings[:vardir], 'simp', 'simpkv', 'file',
-        'auto_default', environment, key)
       expect( File.exist?(key_file) ).to be false
     end
 
@@ -110,11 +107,11 @@ describe 'simpkv::delete' do
       is_expected.to run.with_params(key, @options_test_file).and_return(true)
     end
 
-    it 'should use environment-less key when environment is empty' do
+    it 'should use global key when global config is set' do
       options = @options_default.dup
-      options['environment'] = ''
-      FileUtils.mkdir_p(@root_path_default)
-      key_file = File.join(@root_path_default, key)
+      options['global'] = true
+      key_file = File.join(@root_path_default, 'globals', key)
+      FileUtils.mkdir_p(File.dirname(key_file))
       FileUtils.touch(key_file)
 
       is_expected.to run.with_params(key, options).and_return(true)
@@ -133,27 +130,6 @@ describe 'simpkv::delete' do
       is_expected.to run.with_params(key, options).and_return(false)
 
       #FIXME check warning log
-    end
-  end
-
-  context 'with simpkv::options' do
-    let(:hieradata) { 'multiple_backends_missing_default' }
-
-    it 'should merge simpkv::options' do
-      # @options_default will add the missing default backend config and
-      # override the environment setting.  To spot check options merge (which
-      # is fully tested elsewhere), remove the environment setting and verify
-      # we use the default config from the local options Hash and the
-      # environment from simpkv::options
-      options = @options_default.dup
-      options.delete('environment')
-      default_keydir = File.join(@root_path_default, 'myenv')
-      FileUtils.mkdir_p(default_keydir)
-      key_file = File.join(default_keydir, 'key')
-      FileUtils.touch(key_file)
-
-      is_expected.to run.with_params('key', options).and_return(true)
-      expect( File.exist?(key_file) ).to be false
     end
   end
 

--- a/spec/functions/simpkv/exists_spec.rb
+++ b/spec/functions/simpkv/exists_spec.rb
@@ -2,8 +2,11 @@ require 'spec_helper'
 
 describe 'simpkv::exists' do
 
-# Going to use file plugin and the test plugins in spec/support/test_plugins
-# for these unit tests.
+  # tell puppet-rspec to set Puppet environment to 'myenv'
+  let(:environment) { 'myenv' }
+
+  # Going to use file plugin and the test plugins in spec/support/test_plugins
+  # for these unit tests.
   before(:each) do
     # set up configuration for the file plugin
     @tmpdir = Dir.mktmpdir
@@ -11,7 +14,6 @@ describe 'simpkv::exists' do
     @root_path_default_app_id = File.join(@tmpdir, 'simpkv', 'default_app_id')
     @root_path_default        = File.join(@tmpdir, 'simpkv', 'default')
     options_base = {
-      'environment' => 'production',
       'backends'    => {
         # will use failer plugin for catastrophic error cases, because
         # it is badly behaved and raises exceptions on all operations
@@ -48,13 +50,10 @@ describe 'simpkv::exists' do
     FileUtils.remove_entry_secure(@tmpdir)
   end
 
-  # The tests will verify most of the function behavior without simpkv::options
-  # specified and then verify options merging when simpkv::options is specified.
-
-  context 'without simpkv::options' do
-    let(:test_file_keydir) { File.join(@root_path_test_file, 'production') }
-    let(:default_app_id_keydir) { File.join(@root_path_default_app_id, 'production') }
-    let(:default_keydir) { File.join(@root_path_default, 'production') }
+  context 'basic operation' do
+    let(:test_file_keydir) { File.join(@root_path_test_file, 'environments', environment) }
+    let(:default_app_id_keydir) { File.join(@root_path_default_app_id, 'environments', environment) }
+    let(:default_keydir) { File.join(@root_path_default, 'environments', environment) }
     let(:key) { 'mykey' }
 
     it 'should return true when the key exists at a specific backend in options' do
@@ -93,7 +92,7 @@ describe 'simpkv::exists' do
       # is constructed
       subject()
       key_file = File.join(Puppet.settings[:vardir], 'simp', 'simpkv', 'file',
-        'auto_default', environment, key)
+        'auto_default', 'environments', environment, key)
       FileUtils.mkdir_p(File.dirname(key_file))
       FileUtils.touch(key_file)
 
@@ -117,11 +116,11 @@ describe 'simpkv::exists' do
       is_expected.to run.with_params('missing/sub/dir', @options_test_file).and_return(false)
     end
 
-    it 'should use environment-less key when environment is empty' do
+    it 'should use global key when global config is set' do
       options = @options_default.dup
-      options['environment'] = ''
-      FileUtils.mkdir_p(@root_path_default)
-      key_file = File.join(@root_path_default, key)
+      options['global'] = true
+      key_file = File.join(@root_path_default, 'globals', key)
+      FileUtils.mkdir_p(File.dirname(key_file))
       FileUtils.touch(key_file)
 
       is_expected.to run.with_params(key, options).and_return(true)
@@ -139,26 +138,6 @@ describe 'simpkv::exists' do
       is_expected.to run.with_params(key, options).and_return(nil)
 
       #FIXME check warning log
-    end
-  end
-
-  context 'with simpkv::options' do
-    let(:hieradata) { 'multiple_backends_missing_default' }
-
-    it 'should merge simpkv::options' do
-      # @options_default will add the missing default backend config and
-      # override the environment setting.  To spot check options merge (which
-      # is fully tested elsewhere), remove the environment setting and verify
-      # we use the default config from the local options Hash and the
-      # environment from simpkv::options
-      options = @options_default.dup
-      options.delete('environment')
-      default_keydir = File.join(@root_path_default, 'myenv')
-      FileUtils.mkdir_p(default_keydir)
-      key_file = File.join(default_keydir, 'key')
-      FileUtils.touch(key_file)
-
-      is_expected.to run.with_params('key', options).and_return(true)
     end
   end
 

--- a/spec/support/modules/simpkv_test/manifests/delete.pp
+++ b/spec/support/modules/simpkv_test/manifests/delete.pp
@@ -1,35 +1,48 @@
+# Delete a subset of keys from the backend mapped to an app_id and verify
+# only those keys were deleted
 class simpkv_test::delete inherits simpkv_test::params
 {
-  # Delete keys without metadata for the specified app_id
-  $::simpkv_test::params::key_value_pairs.each |$key, $value| {
-    simpkv::delete($key, $::simpkv_test::params::simpkv_options)
+  # Delete Puppet env keys without metadata for the specified app_id
+  $simpkv_test::params::key_value_pairs.each |$key, $value| {
+    simpkv::delete($key, $simpkv_test::params::simpkv_options)
   }
 
-  # Verify keys without metadata no longer exist for the specified app_id
-  $::simpkv_test::params::key_value_pairs.each |$key, $value| {
+  # Verify Puppet env keys without metadata no longer exist for the specified
+  # app_id
+  $simpkv_test::params::key_value_pairs.each |$key, $value| {
     simpkv_test::assert_equal(
-      simpkv::exists($key, $::simpkv_test::params::simpkv_options),
+      simpkv::exists($key, $simpkv_test::params::simpkv_options),
       false,
-      "simpkv::exists('${key}')"
+      "simpkv::exists('${key}', ${simpkv_test::params::simpkv_options})"
     )
   }
 
-  # Verify keys with metadata still exist for the specified app_id
-  $::simpkv_test::params::key_value_pairs.each |$key, $value| {
+  # Verify global keys without still exist for the specified app_id
+  $simpkv_test::params::key_value_pairs.each |$key, $value| {
     simpkv_test::assert_equal(
-      simpkv::exists("${key}_with_meta", $::simpkv_test::params::simpkv_options),
+      simpkv::exists($key, $simpkv_test::params::simpkv_global_options),
       true,
-      "simpkv::exists('${key}_with_meta')"
+      "simpkv::exists('${key}', ${simpkv_test::params::simpkv_global_options})"
     )
   }
 
-  # Verify the key added in own Puppet function call for the specified app_id still exists
+  # Verify Puppet env keys with metadata still exist for the specified app_id
+  $simpkv_test::params::key_value_pairs.each |$key, $value| {
+    simpkv_test::assert_equal(
+      simpkv::exists("${key}_with_meta", $simpkv_test::params::simpkv_options),
+      true,
+      "simpkv::exists('${key}_with_meta', ${simpkv_test::params::simpkv_options})"
+    )
+  }
+
+  # Verify the Puppet env key added in a Puppet function call for the specified
+  # app_id still exists
   simpkv_test::assert_equal(
     simpkv::exists(
-      "${::simpkv_test::params::test_keydir}/boolean_from_pfunction",
-      $::simpkv_test::params::simpkv_options
+      "${simpkv_test::params::test_keydir}/boolean_from_pfunction",
+      $simpkv_test::params::simpkv_options
     ),
     true,
-    "simpkv::exists('#{::simpkv_test::params::test_keydir}}/boolean_from_pfunction')"
+    "simpkv::exists('${simpkv_test::params::test_keydir}}/boolean_from_pfunction',${simpkv_test::params::simpkv_options})"
   )
 }

--- a/spec/support/modules/simpkv_test/manifests/deletetree.pp
+++ b/spec/support/modules/simpkv_test/manifests/deletetree.pp
@@ -1,30 +1,44 @@
+# Delete parent dirs of Puppet env and global keys from the backend mapped to
+# an app_id and verify all keys were deleted
 class simpkv_test::deletetree inherits simpkv_test::params
 {
-  # Delete parent dir of keys for the specified app_id
-  simpkv::deletetree($::simpkv_test::params::test_keydir, $::simpkv_test::params::simpkv_options)
+  # Delete parent dir of global keys for the specified app_id
+  simpkv::deletetree($simpkv_test::params::test_keydir, $simpkv_test::params::simpkv_global_options)
 
-  # Verify keys with and without metadata no longer exist for the specified app_id
-  $::simpkv_test::params::key_value_pairs.each |$key, $value| {
+  # Verify global keys no longer exist for the specified app_id
+  $simpkv_test::params::key_value_pairs.each |$key, $value| {
     simpkv_test::assert_equal(
-      simpkv::exists($key, $::simpkv_test::params::simpkv_options),
+      simpkv::exists($key, $simpkv_test::params::simpkv_global_options),
       false,
-      "simpkv::exists('${key}')"
+      "simpkv::exists('${key}', ${simpkv_test::params::simpkv_global_options})"
+    )
+  }
+
+  # Delete parent dir of Puppet env keys for the specified app_id
+  simpkv::deletetree($simpkv_test::params::test_keydir, $simpkv_test::params::simpkv_options)
+
+  # Verify Puppet env keys with and without metadata no longer exist for the specified app_id
+  $simpkv_test::params::key_value_pairs.each |$key, $value| {
+    simpkv_test::assert_equal(
+      simpkv::exists($key, $simpkv_test::params::simpkv_options),
+      false,
+      "simpkv::exists('${key}', ${simpkv_test::params::simpkv_options})"
     )
 
     simpkv_test::assert_equal(
-      simpkv::exists("${key}_with_meta", $::simpkv_test::params::simpkv_options),
+      simpkv::exists("${key}_with_meta", $simpkv_test::params::simpkv_options),
       false,
-      "simpkv::exists('${key}_with_meta')"
+      "simpkv::exists('${key}_with_meta', ${simpkv_test::params::simpkv_options})"
     )
   }
 
   # Verify the key added in own Puppet function call for the specified app_id no longer exists
   simpkv_test::assert_equal(
     simpkv::exists(
-      "${::simpkv_test::params::test_keydir}/boolean_from_pfunction",
-      $::simpkv_test::params::simpkv_options
+      "${simpkv_test::params::test_keydir}/boolean_from_pfunction",
+      $simpkv_test::params::simpkv_options
     ),
     false,
-    "simpkv::exists('#{::simpkv_test::params::test_keydir}}/boolean_from_pfunction')"
+    "simpkv::exists('${simpkv_test::params::test_keydir}}/boolean_from_pfunction',${simpkv_test::params::simpkv_options})"
   )
 }

--- a/spec/support/modules/simpkv_test/manifests/exists.pp
+++ b/spec/support/modules/simpkv_test/manifests/exists.pp
@@ -1,49 +1,55 @@
+# Check for the existance of keys stored via the simpkv_test::put Class
+#
+# FIXME: Not checking keys from simpkv_test::defines::put Defines
+#
 class simpkv_test::exists inherits simpkv_test::params
 {
   # Check for keys with and without metadata for the specified app_id
-  $::simpkv_test::params::key_value_pairs.each |$key, $value| {
+  $simpkv_test::params::key_value_pairs.each |$key, $value| {
+    # Puppet env keys without metadata
     simpkv_test::assert_equal(
-      simpkv::exists($key, $::simpkv_test::params::simpkv_options),
+      simpkv::exists($key, $simpkv_test::params::simpkv_options),
       true,
-      "simpkv::exists('${key}')"
+      "simpkv::exists('${key}', ${simpkv_test::params::simpkv_options})"
     )
 
+    # Puppet env keys witht metadata
     simpkv_test::assert_equal(
-      simpkv::exists("${key}_with_meta", $::simpkv_test::params::simpkv_options),
+      simpkv::exists("${key}_with_meta", $simpkv_test::params::simpkv_options),
       true,
-      "simpkv::exists('${key}_with_meta')"
+      "simpkv::exists('${key}_with_meta', ${simpkv_test::params::simpkv_options})"
+    )
+
+    # global keys without metadata
+    simpkv_test::assert_equal(
+      simpkv::exists("${key}", $simpkv_test::params::simpkv_global_options),
+      true,
+      "simpkv::exists('${key}_with_meta', ${simpkv_test::params::simpkv_global_options})"
     )
   }
 
 
-  # Check for the key added in own Puppet function call for the specified app_id
+  # Check for the Puppet env key added in a Puppet function call for the
+  # specified app_id.
   simpkv_test::assert_equal(
     simpkv::exists(
-      "${::simpkv_test::params::test_keydir}/boolean_from_pfunction",
-      $::simpkv_test::params::simpkv_options
+      "${simpkv_test::params::test_keydir}/boolean_from_pfunction",
+      $simpkv_test::params::simpkv_options
     ),
     true,
-    "simpkv::exists('#{::simpkv_test::params::test_keydir}}/boolean_from_pfunction')"
+    "simpkv::exists('${simpkv_test::params::test_keydir}}/boolean_from_pfunction', ${simpkv_test::params::simpkv_options})"
   )
 
-  # Check for the key added in own Puppet function call without the specified app_id.
-  # Should be in default backend but not the backend for the app_id.
+  # Check for the Puppet env key added in a Puppet function call without the
+  # specified app_id. Should be in default backend but not the backend for the
+  # app_id.
   $_empty_simpkv_options = {}
   simpkv_test::assert_equal(
     simpkv::exists(
-      "${::simpkv_test::params::test_keydir}/boolean_from_pfunction_no_app_id",
+      "${simpkv_test::params::test_keydir}/boolean_from_pfunction_no_app_id",
       $_empty_simpkv_options
     ),
     true,
-    "simpkv::exists('#{::simpkv_test::params::test_keydir}}/boolean_from_pfunction_no_appid') default backend"
-  )
-
-  simpkv_test::assert_equal(
-    simpkv::exists(
-      "${::simpkv_test::params::test_keydir}/boolean_from_pfunction_no_app_id",
-      $::simpkv_test::params::simpkv_options
-    ),
-    false,
-    "simpkv::exists('#{::simpkv_test::params::test_keydir}}/boolean_from_pfunction_no_appid') backend for app_id"
+    "simpkv::exists('${simpkv_test::params::test_keydir}}/boolean_from_pfunction_no_appid')"
   )
 }

--- a/spec/support/modules/simpkv_test/manifests/get.pp
+++ b/spec/support/modules/simpkv_test/manifests/get.pp
@@ -1,28 +1,36 @@
 class simpkv_test::get inherits simpkv_test::params
 {
-  # Get keys with and without metadata for the specified app_id
   $_empty_test_meta = {}
-  $::simpkv_test::params::key_value_pairs.each |$key, $value| {
+  $simpkv_test::params::key_value_pairs.each |$key, $value| {
+    # Get and verify Puppet env keys without metadata for the specified app_id
     simpkv_test::assert_equal(
-      simpkv::get($key, $::simpkv_test::params::simpkv_options),
+      simpkv::get($key, $simpkv_test::params::simpkv_options),
       { 'value' => $value },
-      "simpkv::get('${key}')"
+      "simpkv::get('${key}', ${simpkv_test::params::simpkv_options})"
     )
 
+    # Get and verify global keys without metadata for the specified app_id
     simpkv_test::assert_equal(
-      simpkv::get("${key}_with_meta", $::simpkv_test::params::simpkv_options),
-      { 'value' => $value, 'metadata' => $::simpkv_test::params::test_meta },
-      "simpkv::get('${key}_with_meta')"
+      simpkv::get($key, $simpkv_test::params::simpkv_global_options),
+      { 'value' => $value },
+      "simpkv::get('${key}', ${simpkv_test::params::simpkv_global_options})"
+    )
+
+    # Get and verify Puppet env keys with metadata for the specified app_id
+    simpkv_test::assert_equal(
+      simpkv::get("${key}_with_meta", $simpkv_test::params::simpkv_options),
+      { 'value' => $value, 'metadata' => $simpkv_test::params::test_meta },
+      "simpkv::get('${key}_with_meta',${simpkv_test::params::simpkv_options})"
     )
   }
 
   # Get key added in own Puppet function call for the specified app_id
   simpkv_test::assert_equal(
     simpkv::get(
-      "${::simpkv_test::params::test_keydir}/boolean_from_pfunction",
-      $::simpkv_test::params::simpkv_options
+      "${simpkv_test::params::test_keydir}/boolean_from_pfunction",
+      $simpkv_test::params::simpkv_options
     ),
-    { 'value' => $::simpkv_test::params::test_bool },
-    "simpkv::get('${::simpkv_test::params::test_keydir}/boolean_from_pfunction')"
+    { 'value' => $simpkv_test::params::test_bool },
+    "simpkv::get('${simpkv_test::params::test_keydir}/boolean_from_pfunction',${simpkv_test::params::simpkv_options})"
    )
 }

--- a/spec/support/modules/simpkv_test/manifests/list.pp
+++ b/spec/support/modules/simpkv_test/manifests/list.pp
@@ -1,50 +1,79 @@
+# List most of the keys/folders stored via the simpkv_test::put Class
+# 
+# FIXME:
+# - Not checking for keys without an app_id from simpkv_test::put
+# - Not checking keys from simpkv_test::defines::put Defines
 class simpkv_test::list inherits simpkv_test::params
 {
-  $_expected = {
+  $_expected_env = {
     'keys'    => {
-      basename($::simpkv_test::params::test_bool_key)                          => { 'value' => $::simpkv_test::params::test_bool },
-      basename($::simpkv_test::params::test_string_key)                        => { 'value' => $::simpkv_test::params::test_string },
-      basename($::simpkv_test::params::test_integer_key)                       => { 'value' => $::simpkv_test::params::test_integer },
-      basename($::simpkv_test::params::test_float_key)                         => { 'value' => $::simpkv_test::params::test_float },
-      basename($::simpkv_test::params::test_array_strings_key)                 => { 'value' => $::simpkv_test::params::test_array_strings },
-      basename($::simpkv_test::params::test_array_integers_key)                => { 'value' => $::simpkv_test::params::test_array_integers },
-      basename($::simpkv_test::params::test_hash_key)                          => { 'value' => $::simpkv_test::params::test_hash },
+      basename($simpkv_test::params::test_bool_key)                          => { 'value' => $simpkv_test::params::test_bool },
+      basename($simpkv_test::params::test_string_key)                        => { 'value' => $simpkv_test::params::test_string },
+      basename($simpkv_test::params::test_integer_key)                       => { 'value' => $simpkv_test::params::test_integer },
+      basename($simpkv_test::params::test_float_key)                         => { 'value' => $simpkv_test::params::test_float },
+      basename($simpkv_test::params::test_array_strings_key)                 => { 'value' => $simpkv_test::params::test_array_strings },
+      basename($simpkv_test::params::test_array_integers_key)                => { 'value' => $simpkv_test::params::test_array_integers },
+      basename($simpkv_test::params::test_hash_key)                          => { 'value' => $simpkv_test::params::test_hash },
 
-      basename("${::simpkv_test::params::test_bool_key}_with_meta")            => { 'value' => $::simpkv_test::params::test_bool, 'metadata' => $::simpkv_test::params::test_meta },
-      basename("${::simpkv_test::params::test_string_key}_with_meta")          => { 'value' => $::simpkv_test::params::test_string, 'metadata' => $::simpkv_test::params::test_meta },
-      basename("${::simpkv_test::params::test_integer_key}_with_meta")         => { 'value' => $::simpkv_test::params::test_integer, 'metadata' => $::simpkv_test::params::test_meta },
-      basename("${::simpkv_test::params::test_float_key}_with_meta")           => { 'value' => $::simpkv_test::params::test_float, 'metadata' => $::simpkv_test::params::test_meta },
-      basename("${::simpkv_test::params::test_array_strings_key}_with_meta")   => { 'value' => $::simpkv_test::params::test_array_strings, 'metadata' => $::simpkv_test::params::test_meta },
-      basename("${::simpkv_test::params::test_array_integers_key}_with_meta")  => { 'value' => $::simpkv_test::params::test_array_integers, 'metadata' => $::simpkv_test::params::test_meta },
-      basename("${::simpkv_test::params::test_hash_key}_with_meta")            => { 'value' => $::simpkv_test::params::test_hash, 'metadata' => $::simpkv_test::params::test_meta },
+      basename("${simpkv_test::params::test_bool_key}_with_meta")            => { 'value' => $simpkv_test::params::test_bool, 'metadata' => $simpkv_test::params::test_meta },
+      basename("${simpkv_test::params::test_string_key}_with_meta")          => { 'value' => $simpkv_test::params::test_string, 'metadata' => $simpkv_test::params::test_meta },
+      basename("${simpkv_test::params::test_integer_key}_with_meta")         => { 'value' => $simpkv_test::params::test_integer, 'metadata' => $simpkv_test::params::test_meta },
+      basename("${simpkv_test::params::test_float_key}_with_meta")           => { 'value' => $simpkv_test::params::test_float, 'metadata' => $simpkv_test::params::test_meta },
+      basename("${simpkv_test::params::test_array_strings_key}_with_meta")   => { 'value' => $simpkv_test::params::test_array_strings, 'metadata' => $simpkv_test::params::test_meta },
+      basename("${simpkv_test::params::test_array_integers_key}_with_meta")  => { 'value' => $simpkv_test::params::test_array_integers, 'metadata' => $simpkv_test::params::test_meta },
+      basename("${simpkv_test::params::test_hash_key}_with_meta")            => { 'value' => $simpkv_test::params::test_hash, 'metadata' => $simpkv_test::params::test_meta },
 
-      'boolean_from_pfunction'                                                => { 'value' => $::simpkv_test::params::test_bool }
+      'boolean_from_pfunction'                                                => { 'value' => $simpkv_test::params::test_bool }
     },
     'folders' => []
   }
 
   simpkv_test::assert_equal(
-    simpkv::list($::simpkv_test::params::test_keydir, $::simpkv_test::params::simpkv_options),
-    $_expected,
-    "simpkv::list('${::simpkv_test::params::test_keydir}')"
+    simpkv::list($simpkv_test::params::test_keydir, $simpkv_test::params::simpkv_options),
+    $_expected_env,
+    "simpkv::list('${simpkv_test::params::test_keydir}', ${simpkv_test::params::simpkv_options})"
   )
 
-  # top level list for the environment of the simpkv backend specified by
-  # $::simpkv_test::params::simpkv_options
+  $_expected_global = {
+    'keys'    => {
+      basename($simpkv_test::params::test_bool_key)                          => { 'value' => $simpkv_test::params::test_bool },
+      basename($simpkv_test::params::test_string_key)                        => { 'value' => $simpkv_test::params::test_string },
+      basename($simpkv_test::params::test_integer_key)                       => { 'value' => $simpkv_test::params::test_integer },
+      basename($simpkv_test::params::test_float_key)                         => { 'value' => $simpkv_test::params::test_float },
+      basename($simpkv_test::params::test_array_strings_key)                 => { 'value' => $simpkv_test::params::test_array_strings },
+      basename($simpkv_test::params::test_array_integers_key)                => { 'value' => $simpkv_test::params::test_array_integers },
+      basename($simpkv_test::params::test_hash_key)                          => { 'value' => $simpkv_test::params::test_hash }
+    },
+    'folders' => []
+  }
+
   simpkv_test::assert_equal(
-    simpkv::list('/', $::simpkv_test::params::simpkv_options),
-    {keys => {}, folders => [  $::simpkv_test::params::test_keydir ]},
-    "simpkv::list('/', ${::simpkv_test::params::simpkv_options})"
+    simpkv::list($simpkv_test::params::test_keydir, $simpkv_test::params::simpkv_global_options),
+    $_expected_global,
+    "simpkv::list('${simpkv_test::params::test_keydir}', ${simpkv_test::params::simpkv_global_options})"
   )
 
-
-  # top level list overall for the simpkv backend specified by
-  # $::simpkv_test::params::simpkv_options (i.e., the list of environments
-  # for the backend)
-  $_options = deep_merge($::simpkv_test::params::simpkv_options, { 'environment' => '' })
+  # top level list for the Puppet env of the simpkv backend specified by
+  # $simpkv_test::params::simpkv_options
   simpkv_test::assert_equal(
-    simpkv::list('/', $_options),
-    {keys => {}, folders => ['production']},
-    "simpkv::list('/', ${_options})"
+    simpkv::list('/', $simpkv_test::params::simpkv_options),
+    {keys => {}, folders => [  $simpkv_test::params::test_keydir ]},
+    "simpkv::list('/', ${simpkv_test::params::simpkv_options})"
+  )
+
+  # top level list for global keys of the simpkv backend specified by
+  # $simpkv_test::params::simpkv_options
+  simpkv_test::assert_equal(
+    simpkv::list('/', $simpkv_test::params::simpkv_global_options),
+    {keys => {}, folders => [  $simpkv_test::params::test_keydir ]},
+    "simpkv::list('/', ${simpkv_test::params::simpkv_global_options})"
+  )
+
+  # top level list for global keys for default backend
+  $_default_global_options = { 'global' => true }
+  simpkv_test::assert_equal(
+    simpkv::list('/', $_default_global_options),
+    {keys => {}, folders => []},
+    "simpkv::list('/', ${_default_global_options})"
   )
 }

--- a/spec/support/modules/simpkv_test/manifests/params.pp
+++ b/spec/support/modules/simpkv_test/manifests/params.pp
@@ -27,5 +27,7 @@ class simpkv_test::params (
                                               $test_hash_key           => $test_hash },
 
   Hash           $test_meta               = { 'some' => 'metadata' },
-  Hash           $simpkv_options           = { 'app_id' => 'simpkv_test_class' }
+  String         $app_id                  = 'simpkv_test_class',
+  Hash           $simpkv_options          = { 'app_id' => $app_id },
+  Hash           $simpkv_global_options   = { 'app_id' => $app_id, 'global' => true }
 ) { }

--- a/spec/support/modules/simpkv_test/manifests/put.pp
+++ b/spec/support/modules/simpkv_test/manifests/put.pp
@@ -1,40 +1,45 @@
 class simpkv_test::put inherits simpkv_test::params
 {
-  # Add keys without metadata for the specified app_id
   $_empty_test_meta = {}
-  $::simpkv_test::params::key_value_pairs.each |$key, $value| {
+  $simpkv_test::params::key_value_pairs.each |$key, $value| {
+    # Add Puppet env keys without metadata for the specified app_id
     simpkv::put(
       $key,
       $value,
       $_empty_test_meta,
-      $::simpkv_test::params::simpkv_options
+      $simpkv_test::params::simpkv_options
     )
-  }
 
-
-  # Add keys with metadata for the specified app_id
-  $::simpkv_test::params::key_value_pairs.each |$key, $value| {
+    # Add Puppet env keys with metadata for the specified app_id
     simpkv::put(
       "${key}_with_meta",
       $value,
-      $::simpkv_test::params::test_meta,
-      $::simpkv_test::params::simpkv_options
+      $simpkv_test::params::test_meta,
+      $simpkv_test::params::simpkv_options
+    )
+
+    # Add global env keys without metadata for the specified app_id
+    simpkv::put(
+      $key,
+      $value,
+      $_empty_test_meta,
+      $simpkv_test::params::simpkv_global_options
     )
   }
 
-  # Add key within our own Puppet function call for the specified app_id
+  # Add Puppet env key within a Puppet function call for the specified app_id.
   simpkv_test::put_pwrapper(
-    "${::simpkv_test::params::test_keydir}/boolean_from_pfunction",
-    $::simpkv_test::params::test_bool,
-    $::simpkv_test::params::simpkv_options
+    "${simpkv_test::params::test_keydir}/boolean_from_pfunction",
+    $simpkv_test::params::test_bool,
+    $simpkv_test::params::simpkv_options
   )
 
-  # Add key within our own Puppet function call but without the app_id.
+  # Add Puppet env key within a Puppet function call but without the app_id.
   # This key will be stored in the default backend.
   $_empty_simpkv_options = {}
   simpkv_test::put_pwrapper(
-    "${::simpkv_test::params::test_keydir}/boolean_from_pfunction_no_app_id",
-    $::simpkv_test::params::test_bool,
+    "${simpkv_test::params::test_keydir}/boolean_from_pfunction_no_app_id",
+    $simpkv_test::params::test_bool,
     $_empty_simpkv_options
   )
 }

--- a/spec/unit/puppet_x/simpkv/file_plugin_spec.rb
+++ b/spec/unit/puppet_x/simpkv/file_plugin_spec.rb
@@ -93,6 +93,8 @@ describe 'simpkv file plugin anonymous class' do
       it 'should create the root_path tree when none exists' do
         expect{ plugin_class.new(@plugin_name, @options) }.to_not raise_error
         expect( Dir.exist?(@root_path) ).to be true
+        expect( Dir.exist?(File.join(@root_path, 'globals')) ).to be true
+        expect( Dir.exist?(File.join(@root_path, 'environments')) ).to be true
       end
 
       it 'should not fail if the root_path tree exists' do


### PR DESCRIPTION
- BREAKING CHANGES:
  - Added 'globals' and 'environments' root directories for global and
    Puppet-environment keys, respectively, in the normalized key paths
    in the backend.
    - This change makes the top-level organization of keys in the backend
      explicit, and thus more understandable.
    - The prefix used for global keys was changed from `<keystore root dir>` to
      `<keystore root dir>/globals`.
    - The prefix used for environment keys was changed from
      `<keystore root dir>/<specific Puppet environment>` to
      `<keystore root dir>/environments/<specific Puppet environment>`.
    - Change required for the LDAP plugin.
  - Replaced the confusing 'environment' backend option in each simpkv Puppet
    function with a 'global' Boolean option.
    - Global keys are now specified by setting 'global' to true in lieu of
      setting 'environment' to ''.
- Added
  - More detailed plugin exception reporting in order to pinpoint plugin
    logic problems.
    - Now prints out the useful portion of the backtrace when an exception
      is raised.
    - Especially useful during plugin development.
- Maintenance
  - Added explicit documentation on how to use simpkv functions to access
    global keys.
  - Acceptance test Puppet 7, now that we claim support for it.
  - Added a acceptance tests for global keys.
  - Removed unnecessary use of top scope in simpkv_test module.

[SIMP-9774] #close
[SIMP-9697] #comment simp/simpkv changes implemented

[SIMP-9774]: https://simp-project.atlassian.net/browse/SIMP-9774