### PR TITLE
Add RockyLinux 8 support

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -109,14 +109,16 @@ jobs:
     strategy:
       matrix:
         puppet:
-          - label: 'Puppet 7.x'
-            puppet_version: '~> 7.21.0'
+          - label: 'Puppet 7.x [SIMP 6.6/PE 2021.7]'
+            puppet_version: '~> 7.0'
             ruby_version: '2.7'
+            experimental: false
           - label: 'Puppet 8.x'
             puppet_version: '~> 8.0'
-            ruby_version: '3.2'
+            ruby_version: 3.1
+            experimental: true
     env:
-      PUPPET_VERSION: '${{matrix.puppet.puppet_version}}'
+      PUPPET_VERSION: ${{matrix.puppet.puppet_version}}
     steps:
       - uses: actions/checkout@v3
       - name: 'Install Ruby ${{matrix.puppet.ruby_version}}'
@@ -126,6 +128,7 @@ jobs:
           bundler-cache: true
       - run: 'command -v rpm || if command -v apt-get; then sudo apt-get update; sudo apt-get install -y rpm; fi ||:'
       - run: 'bundle exec rake spec'
+        continue-on-error: ${{matrix.puppet.experimental}}
 
 #  dump_contexts:
 #    name: 'Examine Context contents'

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -9,7 +9,7 @@
 --no-class_inherits_from_params_class-check
 --no-140chars-check
 --no-trailing_comma-check
---no-empty_string_assignment-check
+--no-params-empty-string-assignment-check
 # This is here because the code can't handle lookups in parameters and SIMP
 # modules have a LOT of those
 --no-parameter_order-check

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon Jun 12 2023 Chris Tessmer <chris.tessmer@onyxpoint.com> - 0.9.0
+- Add RockyLinux 8 support
+
 * Tue Sep 28 2021 Liz Nemsick <lnemsick.simp@gmail.com> - 0.8.0
 - BREAKING CHANGES:
   - Added 'globals' and 'environments' root directories for global and

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ group :test do
   gem 'puppetlabs_spec_helper'
   gem 'metadata-json-lint'
   gem 'puppet-strings'
-  gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
   gem 'simp-rspec-puppet-facts', ENV['SIMP_RSPEC_PUPPET_FACTS_VERSION'] || '~> 3.1'
   gem 'simp-rake-helpers', ENV['SIMP_RAKE_HELPERS_VERSION'] || ['>= 5.12.1', '< 6']

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simpkv",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "author": "simp",
   "summary": "SIMPkv providers",
   "license": "Apache-2.0",
@@ -14,7 +14,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 6.6.0 < 8.0.0"
+      "version_requirement": ">= 8.0.0 < 9.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -30,6 +30,12 @@
       "operatingsystemrelease": [
         "8",
         "7"
+      ]
+    },
+    {
+      "operatingsystem": "Rocky",
+      "operatingsystemrelease": [
+        "8"
       ]
     }
   ],

--- a/spec/support/modules/simpkv_test/metadata.json
+++ b/spec/support/modules/simpkv_test/metadata.json
@@ -1,17 +1,19 @@
 {
   "name": "simp-simpkv_test",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": "simp",
   "summary": "test manifests for simp kv testing",
   "license": "Apache-2.0",
   "source": "https://github.com/simp/pupmod-simp-simpkv",
   "project_page": "https://github.com/simp/pupmod-simp-simpkv",
   "issues_url": "https://simp-project.atlassian.net",
-  "tags": [],
+  "tags": [
+
+  ],
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.9.0"
+      "version_requirement": ">= 8.0.0 < 9.0.0"
     },
     {
       "name": "simp/simpkv",

--- a/spec/support/modules/test_plugins1/metadata.json
+++ b/spec/support/modules/test_plugins1/metadata.json
@@ -7,8 +7,12 @@
   "source": "https://github.com/simp/pupmod-simp-simpkv",
   "project_page": "https://github.com/simp/pupmod-simp-simpkv",
   "issues_url": "https://simp-project.atlassian.net",
-  "tags": [],
-  "dependencies": [],
+  "tags": [
+
+  ],
+  "dependencies": [
+
+  ],
   "requirements": [
     {
       "name": "puppet",

--- a/spec/support/modules/test_plugins2/metadata.json
+++ b/spec/support/modules/test_plugins2/metadata.json
@@ -7,8 +7,12 @@
   "source": "https://github.com/simp/pupmod-simp-simpkv",
   "project_page": "https://github.com/simp/pupmod-simp-simpkv",
   "issues_url": "https://simp-project.atlassian.net",
-  "tags": [],
-  "dependencies": [],
+  "tags": [
+
+  ],
+  "dependencies": [
+
+  ],
   "requirements": [
     {
       "name": "puppet",


### PR DESCRIPTION
This patch adds support for RockyLinux 8

The patch enforces a standardized asset baseline using simp/puppetsync,
and may also apply other updates to ensure conformity.