### PR TITLE
Remove unmaintained Compliance Engine data

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -14,7 +14,6 @@ fixtures:
     # This needs to be in place for the rspec-puppet Hiera 5 hook to work
     # No idea why, it may be because Puppet sees a custom backend and loads all
     # of the global parts.
-    compliance_markup: https://github.com/simp/pupmod-simp-compliance_markup.git
   symlinks:
     simpkv: "#{source_dir}"
     test_plugins1: "#{File.join(source_dir, 'spec', 'support', 'modules', 'test_plugins1')}"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,10 +31,6 @@ default_hiera_config = <<~HIERA_CONFIG
   ---
   version: 5
   hierarchy:
-    - name: SIMP Compliance Engine
-      lookup_key: compliance_markup::enforcement
-      options:
-        enabled_sce_versions: [2]
     - name: Custom Test Hiera
       path: "%{custom_hiera}.yaml"
     - name: "%{module_name}"


### PR DESCRIPTION
This module never contained `SIMP/compliance_profiles` data, but still carried the `compliance_markup` fixture and the SIMP Compliance Engine Hiera hierarchy entry from when it was wired up for compliance testing.